### PR TITLE
Fix pointing to wrong graphql endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "tslib": "~1.7.x"
   },
   "peerDependencies": {
-    "graphql-anywhere-mongodb": "<2.0.0"
+    "graphql-anywhere-mongodb": ">=0.3.0"
   },
   "devDependencies": {
     "@types/body-parser": "^1.16.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-anywhere-mongodb-express",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "express middleware that accepts graphql requests and runs them as mongo queries",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,10 @@ export default function mongoGraphql(options: MongoGraphQLOptions & GraphQLMongo
 
   // If Graphiql enabled, add it
   if (options.graphiql === true) {
-    router.get('/', graphiqlMiddleware());
+    router.get('/', graphiqlMiddleware({
+      endpoint: options.graphiqlEndpoint,
+      title: options.graphiqlTitle
+    }));
   }
 
   return router;

--- a/src/middlewares/graphiql-html.ts
+++ b/src/middlewares/graphiql-html.ts
@@ -1,6 +1,11 @@
 const GRAPHIQL_VERSION = '0.11.2';
 
-export const GraphiQLHtml = `
+export interface GraphiQLOptions {
+  endpoint?: string;
+  title?: string;
+}
+
+export const graphiQLHtml = ({ endpoint = undefined, title = 'GraphiQL' }: GraphiQLOptions) => `
 <!DOCTYPE html>
 <html>
 <head>
@@ -15,6 +20,7 @@ export const GraphiQLHtml = `
       height: 100vh;
     }
   </style>
+  <title>${title}</title>
 
   <link href="//cdn.jsdelivr.net/npm/graphiql@${GRAPHIQL_VERSION}/graphiql.css" rel="stylesheet" />
   <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
@@ -80,9 +86,8 @@ export const GraphiQLHtml = `
   // use fetch, and could instead implement graphQLFetcher however you like,
   // as long as it returns a Promise or Observable.
   function graphQLFetcher(graphQLParams) {
-    // This example expects a GraphQL server at the path /graphql.
-    // Change this to point wherever you host your GraphQL server.
-    return fetch('/graphql', {
+    var endpoint = ${JSON.stringify(endpoint)} || window.location.pathname;
+    return fetch(endpoint, {
       method: 'post',
       headers: {
         'Accept': 'application/json',

--- a/src/middlewares/serve-graphiql-middleware.ts
+++ b/src/middlewares/serve-graphiql-middleware.ts
@@ -1,8 +1,8 @@
 import { Handler } from 'express';
-import { GraphiQLHtml } from './graphiql-html';
+import { graphiQLHtml, GraphiQLOptions } from './graphiql-html';
 import { handleAsync } from '../handle-async';
 
-export function graphiqlMiddleware(): Handler {
+export function graphiqlMiddleware(options: GraphiQLOptions): Handler {
   return handleAsync((req, res) => {
     // Verify response accepts text/html
     if (!req.accepts('html')) {
@@ -13,7 +13,7 @@ export function graphiqlMiddleware(): Handler {
     }
 
     // Send response
-    const chunk = new Buffer(GraphiQLHtml, 'utf8');
+    const chunk = new Buffer(graphiQLHtml(options), 'utf8');
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
     res.setHeader('Content-Length', String(chunk.length));
     res.end(chunk);

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,9 +1,51 @@
 import { Db, MongoClientOptions } from 'mongodb';
 
 export interface MongoGraphQLOptions {
+  /**
+   * The URI connection string for mongodb.
+   */
   uri?: string;
+
+  /**
+   * The URI connection string for mongodb.
+   */
   url?: string;
-  connection?: Db;
-  graphiql?: boolean;
+
+  /**
+   * Options to pass to the mongo client.
+   */
   mongoClientOptions?: MongoClientOptions;
+
+  /**
+   * Optional pass the mongo driver connection to be used manually.
+   */
+  connection?: any;
+
+  /**
+   * Default MongoDB limit to apply to all graphql requests without a limit.
+   * Defaults to 100.
+   */
+  defaultLimit?: number;
+
+  /**
+   * Maximum MongoDB limit that will be accepted.
+   * Defaults to 10000.
+   */
+  maxLimit?: number;
+
+  /**
+   * If true will expose graphiql
+   */
+  graphiql?: boolean;
+
+  /**
+   * If graphiql = true, then this is the endpoint that graphiql will communicate with.
+   * If not passed, defaults to the path it is hosted off of.
+   */
+  graphiqlEndpoint?: string;
+
+  /**
+   * If graphiql = true, then this is the title for GraphiQL.
+   */
+  graphiqlTitle?: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -731,23 +731,19 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-graphql-anywhere-mongodb@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/graphql-anywhere-mongodb/-/graphql-anywhere-mongodb-0.2.0.tgz#0f8935df4b21e0c428b4b408ca6c00fde6ecf057"
+graphql-anywhere-mongodb@>=0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/graphql-anywhere-mongodb/-/graphql-anywhere-mongodb-0.3.0.tgz#935cfc66804347606889fc5277345e26d370fbd4"
   dependencies:
     debug "^2.6.8"
+    graphql "^0.10.3"
     graphql-anywhere "^3.1.0"
-    graphql-tag "^2.4.2"
     mongodb "^2.2.x"
     tslib "~1.7.x"
 
 graphql-anywhere@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-3.1.0.tgz#3ea0d8e8646b5cee68035016a9a7557c15c21e96"
-
-graphql-tag@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.4.2.tgz#6a63297d8522d03a2b72d26f1b239aab343840cd"
 
 graphql@^0.10.3:
   version "0.10.3"
@@ -1226,19 +1222,19 @@ mocha@^3.4.2:
     mkdirp "0.5.1"
     supports-color "3.1.2"
 
-mongodb-core@2.1.14:
-  version "2.1.14"
-  resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-2.1.14.tgz#13cba2764226b5be3d18992af0c963ce5ea0f0fd"
+mongodb-core@2.1.17:
+  version "2.1.17"
+  resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-2.1.17.tgz#a418b337a14a14990fb510b923dee6a813173df8"
   dependencies:
     bson "~1.0.4"
     require_optional "~1.0.0"
 
 mongodb@^2.2.x:
-  version "2.2.30"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-2.2.30.tgz#8ccd801f676c8172040c2f2b47e9602a0d5634ab"
+  version "2.2.33"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-2.2.33.tgz#b537c471d34a6651b48f36fdbf29750340e08b50"
   dependencies:
     es6-promise "3.2.1"
-    mongodb-core "2.1.14"
+    mongodb-core "2.1.17"
     readable-stream "2.2.7"
 
 ms@0.7.2:
@@ -1611,9 +1607,13 @@ samsam@1.x, samsam@^1.1.3:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
+semver@^5.1.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
 send@0.15.3:
   version "0.15.3"


### PR DESCRIPTION
* Fixed so that graphql endpoint is settable via options OR will default to path its hosted on if not passed.
* Exposed options for defaultLimit and maxLimit
* Bumped to latest graphql-anywhere-mongodb